### PR TITLE
Feature/etherspot balances hook

### DIFF
--- a/__mocks__/@etherspot/react-etherspot.js
+++ b/__mocks__/@etherspot/react-etherspot.js
@@ -1,5 +1,6 @@
 import { AccountTypes } from 'etherspot';
 import ReactEtherspot, { useEtherspot as useEtherspotActual } from '@etherspot/react-etherspot';
+import { ethers } from 'ethers';
 
 export const useEtherspot = () => ({
   ...useEtherspotActual(),
@@ -9,6 +10,19 @@ export const useEtherspot = () => ({
         type: AccountTypes.Contract,
         address: '0x7F30B1960D5556929B03a0339814fE903c55a347',
       },
+    },
+    getAccountBalances: ({ chainId }) => {
+      const tokenBalance = ethers.utils.parseEther('420');
+      const nativeAssetBalance = ethers.utils.parseEther('0');
+
+      const token = { token: '0x', balance: tokenBalance, superBalance: tokenBalance };
+      const nativeAsset = { token: null, balance: nativeAssetBalance, superBalance: nativeAssetBalance };
+
+      const items = chainId === 1
+        ? [nativeAsset, token]
+        : [nativeAsset];
+
+      return { items };
     },
   }),
 });

--- a/__tests__/hooks/useEtherspotBalances.test.js
+++ b/__tests__/hooks/useEtherspotBalances.test.js
@@ -1,0 +1,36 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { ethers } from 'ethers';
+
+// hooks
+import { useEtherspotBalances, EtherspotUi } from '../../src';
+
+describe('useEtherspotBalances()', () => {
+  it('returns balances', async () => {
+    const wrapper = ({ children }) => (
+      <EtherspotUi provider={null}>
+        {children}
+      </EtherspotUi>
+    );
+
+    const { result, rerender } = renderHook(({ chainId }) => useEtherspotBalances(chainId), {
+      initialProps: { chainId: 1 },
+      wrapper,
+    });
+
+    // wait for balances to be fetched for chain ID 1
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current.length).toEqual(2);
+    expect(result.current[0].token).toBeNull();
+    expect(result.current[0].balance.toString()).toEqual(ethers.utils.parseEther('0').toString());
+    expect(result.current[1].token).not.toBeNull();
+    expect(result.current[1].balance.toString()).toEqual(ethers.utils.parseEther('420').toString());
+
+    // rerender with different chain ID 137
+    rerender({ chainId: 137 });
+
+    // wait for balances to be fetched for chain ID 137
+    await waitFor(() => expect(result.current.length).not.toEqual(2));
+    expect(result.current.length).toEqual(1);
+    expect(result.current[0].balance.toString()).toEqual(ethers.utils.parseEther('0').toString());
+  });
+})

--- a/__tests__/hooks/useEtherspotUi.test.js
+++ b/__tests__/hooks/useEtherspotUi.test.js
@@ -2,7 +2,7 @@ import { renderHook, render } from '@testing-library/react';
 import { ethers } from 'ethers';
 
 // hooks
-import { useEtherspotUi, EtherspotUi, EtherspotBatches, EtherspotBatch, EtherspotContractTransaction, EtherspotTransaction } from '../src';
+import { useEtherspotUi, EtherspotUi, EtherspotBatches, EtherspotBatch, EtherspotContractTransaction, EtherspotTransaction } from '../../src';
 
 const TestSingleBatchComponent = () => (
   <EtherspotBatches>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@etherspot/transaction-kit",
   "description": "React Etherspot Transaction Kit",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "main": "dist/cjs/index.js",
   "scripts": {
     "rollup:build": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c",

--- a/src/hooks/useEtherspotBalances.ts
+++ b/src/hooks/useEtherspotBalances.ts
@@ -36,7 +36,7 @@ const useEtherspotBalances = (chainId: number = 1): AccountBalance[] | null => {
         });
         if (shouldUpdate) setBalances(items);
       } catch (e) {
-        //
+        console.warn(e);
       }
     }
 

--- a/src/hooks/useEtherspotBalances.ts
+++ b/src/hooks/useEtherspotBalances.ts
@@ -1,0 +1,52 @@
+import { useEtherspot } from '@etherspot/react-etherspot';
+import { useEffect, useState } from 'react';
+import { AccountBalance, AccountTypes } from 'etherspot';
+
+let isConnecting: Promise<any> | undefined;
+
+/**
+ * Hook to fetch account balances
+ * @param chainId {number} - Chain ID
+ * @returns {AccountBalance[] | null} - Account balances
+ */
+const useEtherspotBalances = (chainId: number = 1): AccountBalance[] | null => {
+  const [balances, setBalances] = useState<AccountBalance[] | null>(null);
+  const { connect, getSdkForChainId } = useEtherspot();
+
+
+  useEffect(() => {
+    let shouldUpdate = true;
+
+    const updateBalance = async () => {
+      if (!!isConnecting) return;
+
+      const sdkForChainId = getSdkForChainId(chainId);
+      if (!sdkForChainId) return;
+
+      if (sdkForChainId?.state?.account?.type !== AccountTypes.Contract) {
+        isConnecting = connect(chainId);
+        await isConnecting;
+        isConnecting = undefined;
+      }
+
+      try {
+        const { items } = await sdkForChainId.getAccountBalances({
+          account: sdkForChainId.state.account.address,
+          chainId,
+        });
+        if (shouldUpdate) setBalances(items);
+      } catch (e) {
+        //
+      }
+    }
+
+    updateBalance();
+
+    return () => { shouldUpdate = false; }
+  }, [chainId, getSdkForChainId, connect]);
+
+
+  return balances;
+};
+
+export default useEtherspotBalances;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { default as EtherspotContractTransaction } from './components/EtherspotC
 export { default as EtherspotApprovalTransaction } from './components/EtherspotApprovalTransaction';
 export { default as EtherspotTokenTransferTransaction } from './components/EtherspotTokenTransferTransaction';
 export { default as useEtherspotUi } from './hooks/useEtherspotUi';
+export { default as useEtherspotBalances } from './hooks/useEtherspotBalances';
 export * from './types/EtherspotUi';
 
 export { useEtherspot };


### PR DESCRIPTION
Added `useEtherstpoBalances` hook to pull Etherspot balances of native chain assets and ERC20 tokens.