### PR TITLE
Feature/changelog version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [0.2.0] - 2023-05-12
+
+### Added
+- Added `useEtherspotBalances` hook for Etherspot/EVM related contract
+- Added `useEtherspotUtils` hook for Etherspot/EVM related utils
+- Added `useEtherspotHistory` hook for Etherspot account transactions history
+- Added `useEtherspotNfts` hook for Etherspot account owned NFTs
+
+### Improvements
+- Improved Etherspot SDK session connection flows
+- Added missing warning logs throughout the library
+
+### Breaking Changes
+- Removed current output of `useEtherspotAssets` and added method `getAssets: () => Promise<TokenListToken[]>` that returns a list of assets instead of putting asseets automatically into the state

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@etherspot/transaction-kit",
   "description": "React Etherspot Transaction Kit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/cjs/index.js",
   "scripts": {
     "rollup:build": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c",


### PR DESCRIPTION
### Added
- Added `useEtherspotBalances` hook for Etherspot/EVM related contract
- Added `useEtherspotUtils` hook for Etherspot/EVM related utils
- Added `useEtherspotHistory` hook for Etherspot account transactions history
- Added `useEtherspotNfts` hook for Etherspot account owned NFTs

### Improvements
- Improved Etherspot SDK session connection flows
- Added missing warning logs throughout the library

### Breaking Changes
- Removed current output of `useEtherspotAssets` and added method `getAssets: () => Promise<TokenListToken[]>` that returns a list of assets instead of putting asseets automatically into the state