### PR TITLE
Fix/window context fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.2.3] - 2023-05-30
+- Updated `window` context to not be used within non-browser environments.
+
 ## [0.2.2] - 2023-05-30
 - Updated  `@etherspot/eip1271-verification-util` to version `0.1.1`.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@etherspot/transaction-kit",
   "description": "React Etherspot Transaction Kit",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "dist/cjs/index.js",
   "scripts": {
     "rollup:build": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Buffer as ImportedBuffer } from 'buffer';
-window.Buffer = window.Buffer ?? ImportedBuffer;
+
+if (typeof window !== 'undefined') window.Buffer = window.Buffer ?? ImportedBuffer;
 
 import { useEtherspot } from '@etherspot/react-etherspot';
 


### PR DESCRIPTION
Updated `window` context to not be used within non-browser environments.