### PR TITLE
Feature/prime sdk paymaster support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.9] - 2023-09-29
+
+### Added
+- Updated `@etherspot/prime-sdk` to version `1.2.11`
+- Added `paymaster` prop to `<EtherspotBatches />` which is used for setting custom `paymaster` sent via `etherspot-prime` provider
+
 ## [0.4.8] - 2023-09-27
 
 ### Added

--- a/__tests__/hooks/useEtherspotTransactions.test.js
+++ b/__tests__/hooks/useEtherspotTransactions.test.js
@@ -62,6 +62,15 @@ describe('useEtherspotTransactions()', () => {
             />
           </EtherspotBatch>
         </EtherspotBatches>
+        <EtherspotBatches via={'etherspot-prime'} paymaster={{ url: 'someUrl', api_key: 'someApiKey' }}>
+          <EtherspotBatch chainId={69}>
+            <EtherspotTransaction
+              to={'0x420'}
+              data={'0x69420'}
+              value={'69'}
+            />
+          </EtherspotBatch>
+        </EtherspotBatches>
         <EtherspotBatches>
           <span>test</span>
         </EtherspotBatches>
@@ -72,7 +81,7 @@ describe('useEtherspotTransactions()', () => {
 
     const { result: { current } } = renderHook(() => useEtherspotTransactions(), { wrapper });
 
-    expect(current.batches.length).toBe(5);
+    expect(current.batches.length).toBe(6);
     expect(current.batches[0].batches.length).toBe(1);
     expect(current.batches[0].batches[0].chainId).toBe(123);
     expect(current.batches[0].batches[0].gasTokenAddress).toBe('testGasTokenAddress');
@@ -90,6 +99,7 @@ describe('useEtherspotTransactions()', () => {
     expect(current.batches[2].batches[0].transactions[0].to).toBe('0x420');
     expect(current.batches[2].batches[0].transactions[0].data).toBe('0x69420');
     expect(current.batches[2].batches[0].transactions[0].value.toJSON()).toStrictEqual({ 'hex': '0x03bd913e6c1df40000', 'type': 'BigNumber' });
+    expect(current.batches[3].paymaster).toStrictEqual({ url: 'someUrl', api_key: 'someApiKey' });
   });
 
   it('throws an error if <EtherspotBatches /> within <EtherspotBatches />', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@etherspot/eip1271-verification-util": "^0.1.2",
-        "@etherspot/prime-sdk": "^1.2.10",
+        "@etherspot/prime-sdk": "^1.2.11",
         "@etherspot/react-etherspot": "^1.2.0",
         "buffer": "^6.0.3",
         "ethers": "^5.6.9",
@@ -2566,9 +2566,9 @@
       }
     },
     "node_modules/@etherspot/prime-sdk": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@etherspot/prime-sdk/-/prime-sdk-1.2.10.tgz",
-      "integrity": "sha512-NMxbabmkTPPNodMAC2BJFKz08FjZiUMGfZuRyPZ0HZvx5CVj4KLUr7dUara6ZWP8mSgNBZpMYi+rFGpRy9Viyg==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@etherspot/prime-sdk/-/prime-sdk-1.2.11.tgz",
+      "integrity": "sha512-TxCNUjZd5RVHosPOhDrunpSZLJN5+PQpe5mZGU2wK/ahY+pKE8JhM6sedCvla49d48+afq0ucCzKXrKJOZizvA==",
       "dependencies": {
         "@apollo/client": "3.4.0",
         "@lifi/sdk": "2.2.3",
@@ -2582,8 +2582,8 @@
         "commander": "10.0.1",
         "cross-fetch": "3.1.5",
         "ethers": "5.7.0",
-        "prettier": "2.8.8",
-        "reflect-metadata": "0.1.13"
+        "graphql-ws": "5.14.0",
+        "prettier": "2.8.8"
       }
     },
     "node_modules/@etherspot/prime-sdk/node_modules/@apollo/client": {
@@ -7700,6 +7700,17 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/graphql-ws": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz",
+      "integrity": "sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -14586,9 +14597,9 @@
       }
     },
     "@etherspot/prime-sdk": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@etherspot/prime-sdk/-/prime-sdk-1.2.10.tgz",
-      "integrity": "sha512-NMxbabmkTPPNodMAC2BJFKz08FjZiUMGfZuRyPZ0HZvx5CVj4KLUr7dUara6ZWP8mSgNBZpMYi+rFGpRy9Viyg==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@etherspot/prime-sdk/-/prime-sdk-1.2.11.tgz",
+      "integrity": "sha512-TxCNUjZd5RVHosPOhDrunpSZLJN5+PQpe5mZGU2wK/ahY+pKE8JhM6sedCvla49d48+afq0ucCzKXrKJOZizvA==",
       "requires": {
         "@apollo/client": "3.4.0",
         "@lifi/sdk": "2.2.3",
@@ -14602,8 +14613,8 @@
         "commander": "10.0.1",
         "cross-fetch": "3.1.5",
         "ethers": "5.7.0",
-        "prettier": "2.8.8",
-        "reflect-metadata": "0.1.13"
+        "graphql-ws": "5.14.0",
+        "prettier": "2.8.8"
       },
       "dependencies": {
         "@apollo/client": {
@@ -18503,6 +18514,12 @@
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
+    },
+    "graphql-ws": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz",
+      "integrity": "sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==",
+      "requires": {}
     },
     "has": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@etherspot/transaction-kit",
   "description": "React Etherspot Transaction Kit",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "main": "dist/cjs/index.js",
   "scripts": {
     "rollup:build": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c",
@@ -26,7 +26,7 @@
     "buffer": "^6.0.3",
     "ethers": "^5.6.9",
     "etherspot": "^1.41.2",
-    "@etherspot/prime-sdk": "^1.2.10",
+    "@etherspot/prime-sdk": "^1.2.11",
     "lodash.uniq": "^4.5.0",
     "react": ">=18.2.0",
     "reflect-metadata": "^0.1.13",

--- a/src/providers/EtherspotTransactionKitContextProvider.tsx
+++ b/src/providers/EtherspotTransactionKitContextProvider.tsx
@@ -226,7 +226,7 @@ const EtherspotTransactionKitContextProvider = ({ children }: EtherspotTransacti
           }
 
           try {
-            const estimated = await etherspotPrimeSdkForChainId.estimate();
+            const estimated = await etherspotPrimeSdkForChainId.estimate(estimatedBatches.paymaster);
             const userOpHash = await etherspotPrimeSdkForChainId.send(estimated);
             sentBatches.push({ ...estimatedBatch, via, userOpHash });
           } catch (e) {

--- a/src/types/EtherspotTransactionKit.ts
+++ b/src/types/EtherspotTransactionKit.ts
@@ -2,6 +2,7 @@ import { Fragment, JsonFragment } from '@ethersproject/abi/src.ts/fragments';
 import { BigNumber, BigNumberish } from 'ethers';
 import { ExchangeOffer } from 'etherspot';
 import { Route } from '@lifi/sdk';
+import { PaymasterApi } from '@etherspot/prime-sdk';
 
 export interface ITransaction {
   id?: string;
@@ -43,20 +44,28 @@ export type SentBatch = {
   errorMessage?: string;
 } & (EtherspotSentBatch | EtherspotPrimeSentBatch);
 
-export interface IBatches {
+export type IBatches = IDefaultBatches<undefined>
+  | IDefaultBatches<'etherspot'>
+  | (IDefaultBatches<'etherspot-prime'> & IEtherspotPrimeBatchesExtra);
+
+interface IDefaultBatches<T extends IBatchesWalletType | undefined> {
   id?: string;
   batches?: IBatch[];
   onEstimated?: (estimated: EstimatedBatch[]) => void;
   onSent?: (sent: SentBatch[]) => void;
   skip?: boolean;
-  via?: IBatchesWalletType;
+  via?: T;
 }
 
-export interface IEstimatedBatches extends IBatches {
+interface IEtherspotPrimeBatchesExtra {
+  paymaster?: PaymasterApi,
+}
+
+export type IEstimatedBatches = IBatches & {
   estimatedBatches: EstimatedBatch[];
 }
 
-export interface ISentBatches extends IEstimatedBatches {
+export type ISentBatches = IEstimatedBatches & {
   sentBatches: SentBatch[];
 }
 

--- a/src/types/EtherspotTransactionKit.ts
+++ b/src/types/EtherspotTransactionKit.ts
@@ -44,8 +44,7 @@ export type SentBatch = {
   errorMessage?: string;
 } & (EtherspotSentBatch | EtherspotPrimeSentBatch);
 
-export type IBatches = IDefaultBatches<undefined>
-  | IDefaultBatches<'etherspot'>
+export type IBatches = IDefaultBatches<undefined | 'etherspot'>
   | (IDefaultBatches<'etherspot-prime'> & IEtherspotPrimeBatchesExtra);
 
 interface IDefaultBatches<T extends IBatchesWalletType | undefined> {


### PR DESCRIPTION
- Updated `@etherspot/prime-sdk` to version `1.2.11`
- Added `paymaster` prop to `<EtherspotBatches />` which is used for setting custom `paymaster` sent via `etherspot-prime` provider