### PR TITLE
removed gas token, added prime sdk estimations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.6.1] - 2023-10-17
+
+### Breaking Changes
+- Removed `gasTokenAddress` prop from `<EtherspotBatches />` component due being unsupported in default `etherspot-prime` provider
+
+### Added
+- Added `gasCost` to `etherspot-prime` estimations
+
 ## [0.6.0] - 2023-10-17
 
 ### Breaking Changes

--- a/__tests__/hooks/useEtherspotTransactions.test.js
+++ b/__tests__/hooks/useEtherspotTransactions.test.js
@@ -6,7 +6,7 @@ import { useEtherspotTransactions, EtherspotTransactionKit, EtherspotBatches, Et
 
 const TestSingleBatchComponent = () => (
   <EtherspotBatches>
-    <EtherspotBatch chainId={1} gasTokenAddress={'testGasTokenAddress'}>
+    <EtherspotBatch chainId={1}>
       <EtherspotTransaction
         to={'0x12'}
         data={'0x0'}
@@ -29,7 +29,7 @@ describe('useEtherspotTransactions()', () => {
           test
           <span>
             <EtherspotBatches>
-              <EtherspotBatch chainId={123} gasTokenAddress={'testGasTokenAddress'}>
+              <EtherspotBatch chainId={123}>
                 <EtherspotTransaction
                   to={'0x12'}
                   data={'0x0'}
@@ -75,7 +75,6 @@ describe('useEtherspotTransactions()', () => {
     expect(current.batches.length).toBe(5);
     expect(current.batches[0].batches.length).toBe(1);
     expect(current.batches[0].batches[0].chainId).toBe(123);
-    expect(current.batches[0].batches[0].gasTokenAddress).toBe('testGasTokenAddress');
     expect(current.batches[0].batches[0].transactions.length).toBe(3);
     expect(current.batches[0].batches[0].transactions[1].to).toBe('0x0');
     expect(current.batches[0].batches[0].transactions[1].data).toBe('0xFFF');

--- a/src/components/EtherspotBatch.tsx
+++ b/src/components/EtherspotBatch.tsx
@@ -18,7 +18,7 @@ interface EtherspotBatchProps extends IBatch {
   children?: React.ReactNode;
 }
 
-const EtherspotBatch = ({ children, chainId, gasTokenAddress, id: batchId }: EtherspotBatchProps) => {
+const EtherspotBatch = ({ children, chainId, id: batchId }: EtherspotBatchProps) => {
   const context = useContext(EtherspotBatchesContext);
   const existingBatchContext = useContext(EtherspotBatchContext);
   const componentId = useId();
@@ -36,7 +36,6 @@ const EtherspotBatch = ({ children, chainId, gasTokenAddress, id: batchId }: Eth
     const batch = {
       id: batchId ?? componentId,
       chainId,
-      gasTokenAddress,
       transactions: getObjectSortedByKeys(transactionsPerId),
     };
 
@@ -48,7 +47,7 @@ const EtherspotBatch = ({ children, chainId, gasTokenAddress, id: batchId }: Eth
         return current;
       });
     }
-  }, [componentId, transactionsPerId, chainId, batchId, gasTokenAddress]);
+  }, [componentId, transactionsPerId, chainId, batchId]);
 
   return (
     <EtherspotBatchContext.Provider value={{ setTransactionsPerId, chainId }}>

--- a/src/types/EtherspotTransactionKit.ts
+++ b/src/types/EtherspotTransactionKit.ts
@@ -1,5 +1,5 @@
 import { Fragment, JsonFragment } from '@ethersproject/abi/src.ts/fragments';
-import { BigNumber, BigNumberish } from 'ethers';
+import { BigNumber, BigNumberish, BytesLike } from 'ethers';
 import { ExchangeOffer } from 'etherspot';
 import { Route } from '@lifi/sdk';
 import { PaymasterApi } from '@etherspot/prime-sdk';
@@ -22,13 +22,13 @@ export interface IProviderWalletTransaction {
 export interface IBatch {
   id?: string;
   chainId?: number;
-  gasTokenAddress?: string;
   transactions?: ITransaction[];
 }
 
 export interface EstimatedBatch extends IBatch {
   errorMessage?: string;
   cost?: BigNumber;
+  userOp?: UserOp;
 }
 
 export interface EtherspotPrimeSentBatch extends EstimatedBatch {
@@ -106,3 +106,19 @@ export interface IProviderWalletTransactionSent {
 }
 
 export type IWalletType = 'provider' | 'etherspot-prime';
+
+type EtherspotPromiseOrValue<T> = T | Promise<T>;
+
+interface UserOp {
+  sender: EtherspotPromiseOrValue<string>;
+  nonce: EtherspotPromiseOrValue<BigNumberish>;
+  initCode: EtherspotPromiseOrValue<BytesLike>;
+  callData: EtherspotPromiseOrValue<BytesLike>;
+  callGasLimit: EtherspotPromiseOrValue<BigNumberish>;
+  verificationGasLimit: EtherspotPromiseOrValue<BigNumberish>;
+  preVerificationGas: EtherspotPromiseOrValue<BigNumberish>;
+  maxFeePerGas: EtherspotPromiseOrValue<BigNumberish>;
+  maxPriorityFeePerGas: EtherspotPromiseOrValue<BigNumberish>;
+  paymasterAndData: EtherspotPromiseOrValue<BytesLike>;
+  signature: EtherspotPromiseOrValue<BytesLike>;
+}


### PR DESCRIPTION
### Breaking Changes
- Removed `gasTokenAddress` prop from `<EtherspotBatches />` component due being unsupported in default `etherspot-prime` provider

### Added
- Added `gasCost` to `etherspot-prime` estimations