### PR TITLE
prime sdk 1.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.6.10] - 2023-11-23
 
-### Added Changes
+### Breaking Changes
 - Updated `@etherspot/prime-sdk` to version `1.3.112` that removes `api_key` param from `paymaster` prop, now it's passed via `url` param
 
 ## [0.6.9] - 2023-11-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.6.10] - 2023-11-23
+
+### Added Changes
+- Updated `@etherspot/prime-sdk` to version `1.3.112` that removes `api_key` param from `paymaster` prop, now it's passed via `url` param
+
 ## [0.6.9] - 2023-11-06
 
 ### Added Changes

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -27,14 +27,14 @@
     },
     "..": {
       "name": "@etherspot/transaction-kit",
-      "version": "0.6.0",
+      "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
         "@etherspot/eip1271-verification-util": "^0.1.2",
-        "@etherspot/prime-sdk": "^1.3.2",
+        "@etherspot/prime-sdk": "^1.3.10",
         "buffer": "^6.0.3",
         "ethers": "^5.6.9",
-        "lodash.uniq": "^4.5.0",
+        "lodash": "^4.17.21",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^6.6.7"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@etherspot/transaction-kit",
   "description": "React Etherspot Transaction Kit",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "main": "dist/cjs/index.js",
   "scripts": {
     "rollup:build": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c",
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/etherspot/transaction-kit#readme",
   "dependencies": {
     "@etherspot/eip1271-verification-util": "^0.1.2",
-    "@etherspot/prime-sdk": "^1.3.10",
+    "@etherspot/prime-sdk": "1.3.12",
     "buffer": "^6.0.3",
     "ethers": "^5.6.9",
     "lodash": "^4.17.21",


### PR DESCRIPTION
### Breaking Changes
- Updated `@etherspot/prime-sdk` to version `1.3.112` that removes `api_key` param from `paymaster` prop, now it's passed via `url` param