### PR TITLE
added sending and estimating states to useEtherspotTransactions hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.6.13] - 2024-01-30
+
+### Added Changes
+- Added `isSending`, `isEstimating`, `containsSendingError`, `containsEstimatingError` to `useEtherspotTransactions` hook
+
 ## [0.6.12] - 2024-01-26
 
 ### Added Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.6.13] - 2024-01-30
+## [0.7.0] - 2024-01-30
 
 ### Added Changes
 - Added `isSending`, `isEstimating`, `containsSendingError`, `containsEstimatingError` to `useEtherspotTransactions` hook

--- a/__tests__/hooks/useEtherspotTransactions.test.js
+++ b/__tests__/hooks/useEtherspotTransactions.test.js
@@ -1,4 +1,4 @@
-import { renderHook, render } from '@testing-library/react';
+import { renderHook, render, act, waitFor } from '@testing-library/react';
 import { ethers } from 'ethers';
 
 // hooks
@@ -203,11 +203,33 @@ describe('useEtherspotTransactions()', () => {
 
     const { result } = renderHook(() => useEtherspotTransactions(), { wrapper });
 
-    const estimated = await result.current.estimate();
+    expect(result.current.isEstimating).toBe(false);
+
+    let estimatePromise;
+    act(() => {
+      estimatePromise = result.current.estimate();
+    });
+
+    await waitFor(() => expect(result.current.isEstimating).toBe(true));
+    await waitFor(() => expect(result.current.isEstimating).toBe(false));
+
+    const estimated = await estimatePromise;
+    expect(result.current.containsEstimatingError).toBe(false);
     expect(ethers.BigNumber.isBigNumber(estimated[0].estimatedBatches[0].cost)).toBe(true);
     expect(estimated[0].estimatedBatches[0].cost.toString()).toBe('350000');
 
-    const sent = await result.current.send();
+    expect(result.current.isSending).toBe(false);
+
+    let sendPromise;
+    act(() => {
+      sendPromise = result.current.send();
+    });
+
+    await waitFor(() => expect(result.current.isSending).toBe(true));
+    await waitFor(() => expect(result.current.isSending).toBe(false));
+
+    const sent = await sendPromise;
+    expect(result.current.containsSendingError).toBe(false);
     expect(sent[0].sentBatches[0].userOpHash).toBe('0x7c');
   });
 
@@ -246,7 +268,18 @@ describe('useEtherspotTransactions()', () => {
 
     const { result } = renderHook(() => useEtherspotTransactions(), { wrapper });
 
-    const sent = await result.current.send();
+    expect(result.current.isSending).toBe(false);
+
+    let sendPromise;
+    act(() => {
+      sendPromise = result.current.send();
+    });
+
+    await waitFor(() => expect(result.current.isSending).toBe(true));
+    await waitFor(() => expect(result.current.isSending).toBe(false));
+
+    const sent = await sendPromise;
+    expect(result.current.containsSendingError).toBe(false);
     expect(sent[0].estimatedBatches[0].cost.toString()).toBe('350000');
     expect(sent[0].sentBatches[0].userOpHash).toBe('0x7c');
   });
@@ -308,13 +341,35 @@ describe('useEtherspotTransactions()', () => {
 
     const { result } = renderHook(() => useEtherspotTransactions(), { wrapper });
 
-    const estimated = await result.current.estimate();
+    expect(result.current.isEstimating).toBe(false);
+
+    let estimatePromise;
+    act(() => {
+      estimatePromise = result.current.estimate();
+    });
+
+    await waitFor(() => expect(result.current.isEstimating).toBe(true));
+    await waitFor(() => expect(result.current.isEstimating).toBe(false));
+
+    const estimated = await estimatePromise;
+    expect(result.current.containsEstimatingError).toBe(false);
     expect(estimated[0].estimatedBatches[0].cost.toString()).toBe('350000');
     expect(estimated[0].estimatedBatches[1].cost.toString()).toBe('200000');
     expect(estimated[1].estimatedBatches.length).toBe(0); // has skip prop
     expect(estimated[2].estimatedBatches[0].cost.toString()).toBe('250000');
 
-    const sent = await result.current.send();
+    expect(result.current.isSending).toBe(false);
+
+    let sendPromise;
+    act(() => {
+      sendPromise = result.current.send();
+    });
+
+    await waitFor(() => expect(result.current.isSending).toBe(true));
+    await waitFor(() => expect(result.current.isSending).toBe(false));
+
+    const sent = await sendPromise;
+    expect(result.current.containsSendingError).toBe(false);
     expect(sent[0].sentBatches[0].userOpHash).toBe('0x7c');
     expect(sent[0].sentBatches[1].userOpHash).toBe('0x7d');
     expect(sent[1].sentBatches.length).toBe(0); // has skip prop
@@ -365,11 +420,33 @@ describe('useEtherspotTransactions()', () => {
 
     const { result } = renderHook(() => useEtherspotTransactions(), { wrapper });
 
-    const estimated = await result.current.estimate();
+    expect(result.current.isEstimating).toBe(false);
+
+    let estimatePromise;
+    act(() => {
+      estimatePromise = result.current.estimate();
+    });
+
+    await waitFor(() => expect(result.current.isEstimating).toBe(true));
+    await waitFor(() => expect(result.current.isEstimating).toBe(false));
+
+    const estimated = await estimatePromise;
+    expect(result.current.containsEstimatingError).toBe(false);
     expect(estimated[0].estimatedBatches[0].cost.toString()).toBe('350000');
     expect(estimated[1].estimatedBatches[0].cost.toString()).toBe('325000');
 
-    const sent = await result.current.send();
+    expect(result.current.isSending).toBe(false);
+
+    let sendPromise;
+    act(() => {
+      sendPromise = result.current.send();
+    });
+
+    await waitFor(() => expect(result.current.isSending).toBe(true));
+    await waitFor(() => expect(result.current.isSending).toBe(false));
+
+    const sent = await sendPromise;
+    expect(result.current.containsSendingError).toBe(false);
     expect(sent[0].sentBatches[0].userOpHash).toBe('0x7c');
     expect(sent[1].sentBatches[0].userOpHash).toBe('0x46');
   });
@@ -434,13 +511,35 @@ describe('useEtherspotTransactions()', () => {
 
     const { result } = renderHook(() => useEtherspotTransactions(), { wrapper });
 
-    const estimated = await result.current.estimate();
+    expect(result.current.isEstimating).toBe(false);
+
+    let estimatePromise;
+    act(() => {
+      estimatePromise = result.current.estimate();
+    });
+
+    await waitFor(() => expect(result.current.isEstimating).toBe(true));
+    await waitFor(() => expect(result.current.isEstimating).toBe(false));
+
+    const estimated = await estimatePromise;
+    expect(result.current.containsEstimatingError).toBe(false);
     expect(estimated[0].estimatedBatches[0].cost.toString()).toBe('350000');
     expect(estimated[0].estimatedBatches[1].cost.toString()).toBe('200000');
     expect(estimated[1].estimatedBatches[0].cost.toString()).toBe('325000');
     expect(estimated[2].estimatedBatches[0].cost.toString()).toBe('325000');
 
-    const sent = await result.current.send();
+    expect(result.current.isSending).toBe(false);
+
+    let sendPromise;
+    act(() => {
+      sendPromise = result.current.send();
+    });
+
+    await waitFor(() => expect(result.current.isSending).toBe(true));
+    await waitFor(() => expect(result.current.isSending).toBe(false));
+
+    const sent = await sendPromise;
+    expect(result.current.containsSendingError).toBe(false);
     expect(sent[0].sentBatches[0].userOpHash).toBe('0x7c');
     expect(sent[0].sentBatches[1].userOpHash).toBe('0x7e');
     expect(sent[1].sentBatches[0].userOpHash).toBe('0x46');
@@ -501,8 +600,18 @@ describe('useEtherspotTransactions()', () => {
 
     const { result } = renderHook(() => useEtherspotTransactions(), { wrapper });
 
-    const estimated = await result.current.estimate();
+    expect(result.current.isEstimating).toBe(false);
 
+    let estimatePromise;
+    act(() => {
+      estimatePromise = result.current.estimate();
+    });
+
+    await waitFor(() => expect(result.current.isEstimating).toBe(true));
+    await waitFor(() => expect(result.current.isEstimating).toBe(false));
+
+    const estimated = await estimatePromise;
+    expect(result.current.containsEstimatingError).toBe(false);
     expect(onEstimated1).toBeCalledTimes(1);
     expect(onEstimated2).toBeCalledTimes(1);
     expect(onEstimated1.mock.calls[0][0]).toStrictEqual(estimated[0].estimatedBatches);
@@ -563,7 +672,17 @@ describe('useEtherspotTransactions()', () => {
 
     const { result } = renderHook(() => useEtherspotTransactions(), { wrapper });
 
-    const sent = await result.current.send();
+    expect(result.current.isSending).toBe(false);
+
+    let sendPromise;
+    act(() => {
+      sendPromise = result.current.send();
+    });
+
+    await waitFor(() => expect(result.current.isSending).toBe(true));
+    await waitFor(() => expect(result.current.isSending).toBe(false));
+
+    const sent = await sendPromise;
 
     expect(onSent1).toBeCalledTimes(1);
     expect(onSent2).toBeCalledTimes(1);
@@ -618,8 +737,18 @@ describe('useEtherspotTransactions()', () => {
 
     const { result } = renderHook(() => useEtherspotTransactions(), { wrapper });
 
-    const estimated = await result.current.estimate();
+    expect(result.current.isEstimating).toBe(false);
 
+    let estimatePromise;
+    act(() => {
+      estimatePromise = result.current.estimate();
+    });
+
+    await waitFor(() => expect(result.current.isEstimating).toBe(true));
+    await waitFor(() => expect(result.current.isEstimating).toBe(false));
+
+    const estimated = await estimatePromise;
+    expect(result.current.containsEstimatingError).toBe(true);
     expect(estimated[0].estimatedBatches[0].errorMessage).toBe('Transaction reverted: chain too high');
     expect(estimated[1].estimatedBatches[0].errorMessage).toBe('Transaction reverted: invalid address');
     expect(onEstimated1.mock.calls[0][0]).toStrictEqual(estimated[0].estimatedBatches);
@@ -673,13 +802,34 @@ describe('useEtherspotTransactions()', () => {
 
     const { result } = renderHook(() => useEtherspotTransactions(), { wrapper });
 
-    const estimated = await result.current.estimate();
+    expect(result.current.isEstimating).toBe(false);
 
+    let estimatePromise;
+    act(() => {
+      estimatePromise = result.current.estimate();
+    });
+
+    await waitFor(() => expect(result.current.isEstimating).toBe(true));
+    await waitFor(() => expect(result.current.isEstimating).toBe(false));
+
+    const estimated = await estimatePromise;
+    expect(result.current.containsEstimatingError).toBe(false);
     expect(estimated[0].estimatedBatches[0].cost.toString()).toBe('350000');
     expect(estimated[1].estimatedBatches[0].cost.toString()).toBe('250000');
 
-    const sent = await result.current.send();
+    expect(result.current.isSending).toBe(false);
 
+    let sendPromise;
+    act(() => {
+      sendPromise = result.current.send();
+    });
+
+    await waitFor(() => expect(result.current.isSending).toBe(true));
+    await waitFor(() => expect(result.current.isSending).toBe(false));
+
+    const sent = await sendPromise;
+
+    expect(result.current.containsSendingError).toBe(true);
     expect(sent[0].sentBatches[0].errorMessage).toBe('Transaction reverted: chain too hot');
     expect(sent[1].sentBatches[0].errorMessage).toBe('Transaction reverted: invalid signature');
     expect(onSent1.mock.calls[0][0]).toStrictEqual(sent[0].sentBatches);
@@ -756,12 +906,31 @@ describe('useEtherspotTransactions()', () => {
 
     const { result } = renderHook(() => useEtherspotTransactions(), { wrapper });
 
-    const estimated1 = await result.current.estimate(['test-id-1']);
+    expect(result.current.isEstimating).toBe(false);
+
+    let estimatePromise;
+    act(() => {
+      estimatePromise = result.current.estimate(['test-id-1']);
+    });
+
+    await waitFor(() => expect(result.current.isEstimating).toBe(true));
+    await waitFor(() => expect(result.current.isEstimating).toBe(false));
+
+    const estimated1 = await estimatePromise;
+    expect(result.current.containsEstimatingError).toBe(true);
     expect(estimated1.length).toBe(1);
     expect(estimated1[0].estimatedBatches[0].errorMessage).toBe('Transaction reverted: chain too high');
     expect(onEstimated1.mock.calls[0][0]).toStrictEqual(estimated1[0].estimatedBatches);
 
-    const estimated2 = await result.current.estimate(['test-id-2', 'test-id-3']);
+    act(() => {
+      estimatePromise = result.current.estimate(['test-id-2', 'test-id-3']);
+    });
+
+    await waitFor(() => expect(result.current.isEstimating).toBe(true));
+    await waitFor(() => expect(result.current.isEstimating).toBe(false));
+
+    const estimated2 = await estimatePromise;
+    expect(result.current.containsEstimatingError).toBe(false);
     expect(estimated2.length).toBe(2);
     expect(estimated2[0].estimatedBatches[0].cost.toString()).toBe('325000');
     expect(estimated2[1].estimatedBatches[0].cost.toString()).toBe('200000');
@@ -839,13 +1008,32 @@ describe('useEtherspotTransactions()', () => {
 
     const { result } = renderHook(() => useEtherspotTransactions(), { wrapper });
 
-    const sent1 = await result.current.send(['test-id-1']);
+    expect(result.current.isSending).toBe(false);
+
+    let sendPromise;
+    act(() => {
+      sendPromise = result.current.send(['test-id-1']);
+    });
+
+    await waitFor(() => expect(result.current.isSending).toBe(true));
+    await waitFor(() => expect(result.current.isSending).toBe(false));
+
+    const sent1 = await sendPromise;
     expect(sent1.length).toBe(1);
+    expect(result.current.containsSendingError).toBe(true);
     expect(sent1[0].sentBatches[0].errorMessage).toBe('Transaction reverted: chain too hot');
     expect(onSent1.mock.calls[0][0]).toStrictEqual(sent1[0].sentBatches);
 
-    const sent2 = await result.current.send(['test-id-2', 'test-id-3']);
+    act(() => {
+      sendPromise = result.current.send(['test-id-2', 'test-id-3']);
+    });
+
+    await waitFor(() => expect(result.current.isSending).toBe(true));
+    await waitFor(() => expect(result.current.isSending).toBe(false));
+
+    const sent2 = await sendPromise;
     expect(sent2.length).toBe(2);
+    expect(result.current.containsSendingError).toBe(false);
     expect(sent2[0].sentBatches[0].userOpHash).toBe('0x46');
     expect(sent2[1].sentBatches[0].userOpHash).toBe('0x47');
     expect(onSent2.mock.calls[0][0]).toStrictEqual(sent2[0].sentBatches);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@etherspot/transaction-kit",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@etherspot/transaction-kit",
-      "version": "0.6.12",
+      "version": "0.6.13",
       "license": "MIT",
       "dependencies": {
         "@etherspot/eip1271-verification-util": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@etherspot/transaction-kit",
-  "version": "0.6.13",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@etherspot/transaction-kit",
-      "version": "0.6.13",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@etherspot/eip1271-verification-util": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@etherspot/transaction-kit",
   "description": "React Etherspot Transaction Kit",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "main": "dist/cjs/index.js",
   "scripts": {
     "rollup:build": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@etherspot/transaction-kit",
   "description": "React Etherspot Transaction Kit",
-  "version": "0.6.13",
+  "version": "0.7.0",
   "main": "dist/cjs/index.js",
   "scripts": {
     "rollup:build": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "rollup:build": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c",
     "rollup:watch": "rimraf ./node_modules/react ./node_modules/react-dom && rollup -c -w",
     "test": "jest __tests__ --silent --detectOpenHandles",
-    "test:watch": "jest --watch",
-    "test:update": "jest --silent --updateSnapshot --detectOpenHandles"
+    "test:watch": "jest --watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "rollup:build": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c",
     "rollup:watch": "rimraf ./node_modules/react ./node_modules/react-dom && rollup -c -w",
-    "test": "jest __tests__ --silent",
-    "test:watch": "jest --watch"
+    "test": "jest __tests__ --silent --detectOpenHandles",
+    "test:watch": "jest --watch",
+    "test:update": "jest --silent --updateSnapshot --detectOpenHandles"
   },
   "repository": {
     "type": "git",

--- a/src/contexts/EtherspotTransactionKitContext.tsx
+++ b/src/contexts/EtherspotTransactionKitContext.tsx
@@ -10,6 +10,10 @@ export interface IEtherspotTransactionKitContext {
     batches: IBatches[];
     estimate: (batchesIds?: string[]) => Promise<IEstimatedBatches[]>;
     send: (batchesIds?: string[]) => Promise<ISentBatches[]>;
+    isEstimating: boolean;
+    isSending: boolean;
+    containsSendingError: boolean;
+    containsEstimatingError: boolean;
   },
   setGroupedBatchesPerId: Dispatch<SetStateAction<TypePerId<IBatches>>>;
 }

--- a/src/types/EtherspotTransactionKit.ts
+++ b/src/types/EtherspotTransactionKit.ts
@@ -30,13 +30,10 @@ export interface EstimatedBatch extends IBatch {
   userOp?: UserOp;
 }
 
-export interface EtherspotPrimeSentBatch extends EstimatedBatch {
+export interface SentBatch extends EstimatedBatch {
+  errorMessage?: string;
   userOpHash?: string;
 }
-
-export type SentBatch = {
-  errorMessage?: string;
-} & (EtherspotPrimeSentBatch);
 
 export interface IBatches {
   id?: string;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Added `isSending`, `isEstimating`, `containsSendingError`, `containsEstimatingError` to `useEtherspotTransactions` hook

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally ran example dapp, integration tests to be updated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
