### PR TITLE
separate bundler and data services api keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.10.0] - 2024-03-20
+
+### Breaking Changes
+- Etherspot project keys are now split as `dataApiKey` and `bundlerApiKey` to support separation of bundler and data services, however `TransactionKit` still carries embedded keys with low frequency usage API calls support
+
 ## [0.9.2] - 2024-03-20
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@etherspot/transaction-kit",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@etherspot/transaction-kit",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@etherspot/eip1271-verification-util": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@etherspot/transaction-kit",
   "description": "React Etherspot Transaction Kit",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "main": "dist/cjs/index.js",
   "scripts": {
     "rollup:build": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -37,7 +37,8 @@ export default [
         exclude: ['./example/**', './src/test/**']
       }),
       replace({
-        __ETHERSPOT_PROJECT_KEY__: process.env.ETHERSPOT_PROJECT_KEY ?? '',
+        __ETHERSPOT_DATA_API_KEY__: process.env.ETHERSPOT_DATA_API_KEY ?? '',
+        __ETHERSPOT_BUNDLER_API_KEY__: process.env.ETHERSPOT_BUNDLER_API_KEY ?? '',
         preventAssignment: true,
       }),
     ],

--- a/src/components/EtherspotTransactionKit.tsx
+++ b/src/components/EtherspotTransactionKit.tsx
@@ -13,7 +13,8 @@ interface EtherspotTransactionKitProps extends React.PropsWithChildren {
   provider: WalletProviderLike;
   chainId?: number;
   accountTemplate?: AccountTemplate;
-  projectKey?: string;
+  dataApiKey?: string;
+  bundlerApiKey?: string;
 }
 
 const EtherspotTransactionKit = ({
@@ -21,13 +22,15 @@ const EtherspotTransactionKit = ({
   provider,
   chainId = 1,
   accountTemplate = Factory.ETHERSPOT,
-  projectKey,
+  dataApiKey,
+  bundlerApiKey,
 }: EtherspotTransactionKitProps) => (
   <EtherspotContextProvider
     provider={provider}
     chainId={+chainId} // cast to make it less failproof when passed as string, i.e. from env file
     accountTemplate={accountTemplate}
-    projectKey={projectKey}
+    dataApiKey={dataApiKey}
+    bundlerApiKey={bundlerApiKey}
   >
     <EtherspotTransactionKitContextProvider>
       <ProviderWalletContextProvider>

--- a/src/providers/EtherspotContextProvider.tsx
+++ b/src/providers/EtherspotContextProvider.tsx
@@ -28,13 +28,15 @@ const EtherspotContextProvider = ({
   provider,
   chainId,
   accountTemplate,
-  projectKey,
+  dataApiKey,
+  bundlerApiKey,
 }: {
   children: ReactNode;
   provider: WalletProviderLike;
   chainId: number;
   accountTemplate: AccountTemplate;
-  projectKey?: string;
+  dataApiKey?: string;
+  bundlerApiKey?: string;
 }) => {
   const context = useContext(EtherspotContext);
 
@@ -68,7 +70,7 @@ const EtherspotContextProvider = ({
     // @ts-ignore
     const sdkForChain = new PrimeSdk(mappedProvider ?? provider, {
       chainId: +sdkChainId,
-      etherspotBundlerApiKey: projectKey ?? ('__ETHERSPOT_PROJECT_KEY__' || undefined),
+      etherspotBundlerApiKey: bundlerApiKey ?? ('__ETHERSPOT_BUNDLER_API_KEY__' || undefined),
       factoryWallet: accountTemplate as Factory,
     });
 
@@ -81,13 +83,13 @@ const EtherspotContextProvider = ({
     await sdkForChain.getCounterFactualAddress();
 
     return sdkForChain;
-  }, [provider, chainId, accountTemplate, projectKey]);
+  }, [provider, chainId, accountTemplate, bundlerApiKey]);
 
   const getDataService = useCallback(() => {
     if (dataService) return dataService;
-    dataService = new DataUtils(projectKey ?? ('__ETHERSPOT_PROJECT_KEY__' || undefined));
+    dataService = new DataUtils(dataApiKey ?? ('__ETHERSPOT_DATA_API_KEY__' || undefined));
     return dataService;
-  }, [projectKey]);
+  }, [dataApiKey]);
 
   const contextData = useMemo(() => ({
     getSdk,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Etherspot project keys are now split as `dataApiKey` and `bundlerApiKey` to support separation of bundler and data services, however `TransactionKit` still carries embedded keys with low frequency usage API calls support

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Local tests and example dapp.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
