### PR TITLE
chore/modular-sdk-version-fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@etherspot/transaction-kit",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@etherspot/transaction-kit",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@etherspot/data-utils": "^1.1.1",
         "@etherspot/eip1271-verification-util": "0.1.2",
-        "@etherspot/modular-sdk": "^5.1.0",
+        "@etherspot/modular-sdk": "5.1.0",
         "@ethersproject/abi": "^5.7.0",
         "@lifi/types": "^9.2.0",
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@etherspot/data-utils": "^1.1.1",
     "@etherspot/eip1271-verification-util": "0.1.2",
-    "@etherspot/modular-sdk": "^5.1.0",
+    "@etherspot/modular-sdk": "5.1.0",
     "@ethersproject/abi": "^5.7.0",
     "@lifi/types": "^9.2.0",
     "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@etherspot/transaction-kit",
   "description": "React Etherspot Transaction Kit",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "dist/cjs/index.js",
   "scripts": {
     "rollup:build": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c --bundleConfigAsCjs",


### PR DESCRIPTION
- Locked the version to 5.1.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependency version for "@etherspot/modular-sdk" to require exactly version 5.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->