### PR TITLE
fix/PRO-3396/userOp-retry-sending-options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.1] - 2025-06-04
+
+### Added Changes
+
+- Added `SendOptions` to the `send()` function, allowing an optional retry mechanism if the `useOp.maxFeePerGas` and `userOp.maxPriorityFeePerGas` are too low.
+
 ## [1.1.0] - 2025-05-29
 
 ### Added Changes

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -27,7 +27,8 @@
       }
     },
     "..": {
-      "version": "1.0.5",
+      "name": "@etherspot/transaction-kit",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@etherspot/data-utils": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@etherspot/transaction-kit",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@etherspot/transaction-kit",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@etherspot/data-utils": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@etherspot/transaction-kit",
   "description": "React Etherspot Transaction Kit",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/cjs/index.js",
   "scripts": {
     "rollup:build": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c --bundleConfigAsCjs",

--- a/src/contexts/EtherspotTransactionKitContext.tsx
+++ b/src/contexts/EtherspotTransactionKitContext.tsx
@@ -5,6 +5,7 @@ import {
   IBatches,
   IEstimatedBatches,
   ISentBatches,
+  SendOptions,
 } from '../types/EtherspotTransactionKit';
 import { TypePerId } from '../types/Helper';
 
@@ -13,7 +14,10 @@ export interface IEtherspotTransactionKitContext {
     chainId: number;
     batches: IBatches[];
     estimate: (batchesIds?: string[]) => Promise<IEstimatedBatches[]>;
-    send: (batchesIds?: string[]) => Promise<ISentBatches[]>;
+    send: (
+      batchesIds?: string[],
+      options?: SendOptions
+    ) => Promise<ISentBatches[]>;
     getTransactionHash: (
       userOpHash: string,
       txChainId: number,

--- a/src/types/EtherspotTransactionKit.ts
+++ b/src/types/EtherspotTransactionKit.ts
@@ -201,3 +201,9 @@ export type FallbackInfo = {
   selector: string;
   handlerAddress: string;
 };
+
+export type SendOptions = {
+  retryOnFeeTooLow?: boolean;
+  maxRetries?: number;
+  feeMultiplier?: number;
+};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- SendOptions to allow to retry send with high gas fee if fee is too low error

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Existing Unit Tests and Manual Testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an optional retry mechanism when sending transactions, allowing automatic retries with increased gas fees if initial fees are too low.
  - Introduced new options to customize retry behavior, including maximum retries and fee multipliers.

- **Chores**
  - Updated documentation and versioning to reflect the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->