### PR TITLE
fix/update-transaction-kit-2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.3] - 2025-08-22
+
+### Added Changes
+
+- `chainId` is mandatory in the method `transaction` is mandatory.
+- For `send` and `estimate`, the `etherspotModularSdk` is set with the transaction chainId rather than the provider chainId.
+
 ## [2.0.2] - 2025-07-24
 
 ### Added Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@
 
 ### Added Changes
 
-- `chainId` is mandatory in the method `transaction` is mandatory.
-- For `send` and `estimate`, the `etherspotModularSdk` is set with the transaction chainId rather than the provider chainId.
-
+- `chainId` is mandatory in the `transaction()` method.
+- For `send` and `estimate`, the `etherspotModularSdk` is initialized using the transaction's `chainId` rather than the provider's `chainId`.
 ## [2.0.2] - 2025-07-24
 
 ### Added Changes

--- a/__tests__/EtherspotTransactionKit.test.ts
+++ b/__tests__/EtherspotTransactionKit.test.ts
@@ -193,6 +193,7 @@ describe('EtherspotTransactionKit', () => {
 
     it('should use default values for optional parameters', () => {
       const txParams = {
+        chainId: 1,
         to: '0x1234567890123456789012345678901234567890',
       };
 
@@ -206,7 +207,7 @@ describe('EtherspotTransactionKit', () => {
 
     it('should throw error for missing to address', () => {
       expect(() => {
-        transactionKit.transaction({ to: '' });
+        transactionKit.transaction({ chainId: 1, to: '' });
       }).toThrow('transaction(): to is required.');
     });
 
@@ -214,7 +215,7 @@ describe('EtherspotTransactionKit', () => {
       (isAddress as unknown as jest.Mock).mockReturnValue(false);
 
       expect(() => {
-        transactionKit.transaction({ to: 'invalid-address' });
+        transactionKit.transaction({ chainId: 1, to: 'invalid-address' });
       }).toThrow(`transaction(): 'invalid-address' is not a valid address.`);
     });
 
@@ -230,6 +231,7 @@ describe('EtherspotTransactionKit', () => {
     it('should throw error for invalid value', () => {
       expect(() => {
         transactionKit.transaction({
+          chainId: 1,
           to: '0x1234567890123456789012345678901234567890',
           value: 'invalid',
         });
@@ -241,6 +243,7 @@ describe('EtherspotTransactionKit', () => {
     it('should throw error for negative value', () => {
       expect(() => {
         transactionKit.transaction({
+          chainId: 1,
           to: '0x1234567890123456789012345678901234567890',
           value: '-1',
         });
@@ -251,6 +254,7 @@ describe('EtherspotTransactionKit', () => {
 
     it('should accept bigint value', () => {
       const txParams = {
+        chainId: 1,
         to: '0x1234567890123456789012345678901234567890',
         value: BigInt(1000),
       };
@@ -266,6 +270,7 @@ describe('EtherspotTransactionKit', () => {
   describe('name', () => {
     beforeEach(() => {
       transactionKit.transaction({
+        chainId: 1,
         to: '0x1234567890123456789012345678901234567890',
       });
     });
@@ -319,6 +324,7 @@ describe('EtherspotTransactionKit', () => {
   describe('remove', () => {
     it('should remove named transaction', () => {
       transactionKit.transaction({
+        chainId: 1,
         to: '0x1234567890123456789012345678901234567890',
       });
       transactionKit.name({ transactionName: 'test' });
@@ -341,6 +347,7 @@ describe('EtherspotTransactionKit', () => {
 
     it('should throw error if transaction not named', () => {
       transactionKit.transaction({
+        chainId: 1,
         to: '0x1234567890123456789012345678901234567890',
       });
 
@@ -355,6 +362,7 @@ describe('EtherspotTransactionKit', () => {
   describe('update', () => {
     beforeEach(() => {
       transactionKit.transaction({
+        chainId: 1,
         to: '0x1234567890123456789012345678901234567890',
       });
       transactionKit.name({ transactionName: 'test' });
@@ -380,6 +388,7 @@ describe('EtherspotTransactionKit', () => {
   describe('estimate', () => {
     beforeEach(() => {
       transactionKit.transaction({
+        chainId: 1,
         to: '0x1234567890123456789012345678901234567890',
         value: '1000000000000000000',
         data: '0x1234',
@@ -504,6 +513,7 @@ describe('EtherspotTransactionKit', () => {
     it('should allow transaction with value = 0 and data = 0x', async () => {
       const kit = new EtherspotTransactionKit(mockConfig);
       kit.transaction({
+        chainId: 1,
         to: '0x1234567890123456789012345678901234567890',
         value: '0',
         data: '0x',
@@ -547,6 +557,7 @@ describe('EtherspotTransactionKit', () => {
   describe('send', () => {
     beforeEach(() => {
       transactionKit.transaction({
+        chainId: 1,
         to: '0x1234567890123456789012345678901234567890',
         value: '1000000000000000000',
         data: '0x1234',
@@ -658,6 +669,7 @@ describe('EtherspotTransactionKit', () => {
 
     it('should allow sending transaction with value = 0 and data = 0x', async () => {
       transactionKit.transaction({
+        chainId: 1,
         to: '0x1234567890123456789012345678901234567890',
         value: '0',
         data: '0x',
@@ -743,6 +755,7 @@ describe('EtherspotTransactionKit', () => {
 
     it('should return state with transaction', () => {
       transactionKit.transaction({
+        chainId: 1,
         to: '0x1234567890123456789012345678901234567890',
         value: '1000000000000000000',
       });
@@ -779,6 +792,7 @@ describe('EtherspotTransactionKit', () => {
       expect(() => {
         debugKit.setDebugMode(true);
         debugKit.transaction({
+          chainId: 1,
           to: '0x1234567890123456789012345678901234567890',
         });
         debugKit.name({ transactionName: 'debug-tx' });
@@ -828,6 +842,7 @@ describe('EtherspotTransactionKit', () => {
     it('should reset all state', () => {
       // Set up some state
       transactionKit.transaction({
+        chainId: 1,
         to: '0x1234567890123456789012345678901234567890',
       });
       transactionKit.name({ transactionName: 'test' });
@@ -870,6 +885,7 @@ describe('EtherspotTransactionKit', () => {
   describe('State management during operations', () => {
     beforeEach(() => {
       transactionKit.transaction({
+        chainId: 1,
         to: '0x1234567890123456789012345678901234567890',
         value: '1000000000000000000',
       });
@@ -929,23 +945,24 @@ describe('EtherspotTransactionKit', () => {
   });
 
   describe('Provider integration', () => {
-    it('should handle provider chain ID changes', () => {
+    it('should use explicit chainId from transaction call', () => {
       mockProvider.getChainId.mockReturnValue(5);
 
       transactionKit.transaction({
+        chainId: 1,
         to: '0x1234567890123456789012345678901234567890',
       });
 
       const state = transactionKit.getState();
       expect(state.workingTransaction?.chainId).toBe(1);
 
-      // Test with no explicit chainId
       transactionKit.transaction({
+        chainId: 137,
         to: '0x1234567890123456789012345678901234567890',
         value: '1',
       });
       const state2 = transactionKit.getState();
-      expect(state2.workingTransaction?.chainId).toBe(1); // Should use default
+      expect(state2.workingTransaction?.chainId).toBe(137);
     });
 
     it('should handle SDK instance errors gracefully', async () => {
@@ -972,12 +989,14 @@ describe('Batch operations', () => {
     mockSdk.send.mockReset();
     mockSdk.totalGasEstimated.mockReset();
     transactionKit.transaction({
+      chainId: 1,
       to: '0x1111111111111111111111111111111111111111',
       value: '1000000000000000000',
     });
     transactionKit.name({ transactionName: 'tx1' });
     transactionKit.addToBatch({ batchName: 'batch1' });
     transactionKit.transaction({
+      chainId: 1,
       to: '0x2222222222222222222222222222222222222222',
       value: '2000000000000000000',
     });

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -29,11 +29,11 @@
     },
     "..": {
       "name": "@etherspot/transaction-kit",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@etherspot/eip1271-verification-util": "0.1.2",
-        "@etherspot/modular-sdk": "6.1.0",
+        "@etherspot/modular-sdk": "6.1.1",
         "buffer": "6.0.3",
         "lodash": "4.17.21",
         "viem": "2.21.54"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -39,6 +39,7 @@ const App = () => {
       action: async (logAndUpdateState: (msg: string) => void) => {
         try {
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000dead',
             value: '1000000000000000000',
           });
@@ -57,6 +58,7 @@ const App = () => {
             transactionName: 'tx1',
           }) as INamedTransaction;
           named.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000beef',
             value: '2000000000000000000',
           });
@@ -86,6 +88,7 @@ const App = () => {
       action: async (logAndUpdateState: (msg: string) => void) => {
         try {
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000cafe',
             value: '3000000000000000000',
           });
@@ -104,6 +107,7 @@ const App = () => {
       action: async (logAndUpdateState: (msg: string) => void) => {
         try {
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000babe',
             value: '4000000000000000000',
           });
@@ -252,6 +256,7 @@ const App = () => {
       action: async (logAndUpdateState: (msg: string) => void) => {
         try {
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000f00d',
             value: '5000000000000000000',
           });
@@ -272,6 +277,7 @@ const App = () => {
         try {
           // Ensure tx3 is in batch1
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000babe',
             value: '4000000000000000000',
           });
@@ -295,6 +301,7 @@ const App = () => {
         try {
           // Add tx5 to batch2
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000c0de',
             value: '6000000000000000000',
           });
@@ -304,6 +311,7 @@ const App = () => {
           named.addToBatch({ batchName: 'batch2' });
           // Add tx6 to batch2
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000c0fe',
             value: '7000000000000000000',
           });
@@ -327,6 +335,7 @@ const App = () => {
         try {
           // Ensure tx3 is in batch1
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000babe',
             value: '4000000000000000000',
           });
@@ -336,6 +345,7 @@ const App = () => {
           named.addToBatch({ batchName: 'batch1' });
           // Now update tx3 in batch1
           named.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000feed',
             value: '8880000000000000000',
           });
@@ -353,6 +363,7 @@ const App = () => {
       action: async (logAndUpdateState: (msg: string) => void) => {
         try {
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000aabb',
             value: '1000000000000000000',
           });
@@ -389,6 +400,7 @@ const App = () => {
       action: async (logAndUpdateState: (msg: string) => void) => {
         try {
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000cafe',
             value: '123',
           });
@@ -423,7 +435,7 @@ const App = () => {
       label: 'Add Transaction with Invalid Address',
       action: async (logAndUpdateState: (msg: string) => void) => {
         try {
-          kit.transaction({ to: 'not-an-address', value: '1' });
+          kit.transaction({ chainId: 137, to: 'not-an-address', value: '1' });
           logAndUpdateState('Should not see this.');
         } catch (e) {
           logAndUpdateState('Error: ' + (e as Error).message);
@@ -435,6 +447,7 @@ const App = () => {
       action: async (logAndUpdateState: (msg: string) => void) => {
         try {
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000dead',
             value: '-1',
           });
@@ -474,6 +487,7 @@ const App = () => {
         try {
           // Create empty batchD by adding and removing a tx
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000dede',
             value: '1',
           });
@@ -512,6 +526,7 @@ const App = () => {
         try {
           // Add tx10 to batchE
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000eeee',
             value: '1',
           });
@@ -533,6 +548,7 @@ const App = () => {
       action: async (logAndUpdateState: (msg: string) => void) => {
         try {
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000f0f0',
             value: '1',
           });
@@ -548,6 +564,7 @@ const App = () => {
       action: async (logAndUpdateState: (msg: string) => void) => {
         try {
           kit.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000f1f1',
             value: '1',
           });
@@ -556,6 +573,7 @@ const App = () => {
           }) as INamedTransaction;
           named.addToBatch({ batchName: 'batchF' });
           named.transaction({
+            chainId: 137,
             to: '0x000000000000000000000000000000000000f2f2',
             value: '2',
           });

--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -236,7 +236,7 @@ export interface ToParams {
 }
 
 export interface TransactionParams {
-  chainId?: number;
+  chainId: number;
   to: string;
   value?: bigint | string;
   data?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@etherspot/transaction-kit",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@etherspot/transaction-kit",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@etherspot/eip1271-verification-util": "0.1.2",
-        "@etherspot/modular-sdk": "^6.1.1",
+        "@etherspot/modular-sdk": "6.1.1",
         "buffer": "6.0.3",
         "lodash": "4.17.21",
         "viem": "2.21.54"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@etherspot/transaction-kit",
   "description": "Framework-agnostic Etherspot Transaction Kit",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "dist/cjs/index.js",
   "scripts": {
     "rollup:build": "NODE_OPTIONS=--max-old-space-size=8192 rollup -c --bundleConfigAsCjs",


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
- Update chainId to be mandatory param in transaction and send() and estimate() (single transaction) sdk chainId from the transaction rather than provider.
- Typo for etherspotModularSdk

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Unit tests and manual testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Transactions and batches now use the explicit chainId from each transaction and require chainId when creating transactions.

- Tests
  - Tests updated to pass explicit chain IDs and verify they override provider defaults.

- Documentation
  - Changelog updated for v2.0.3.
  - Example app updated to include explicit chain IDs in transaction scenarios.

- Chores
  - Version bumped to 2.0.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->